### PR TITLE
Update api to v2 and remove extra slashes

### DIFF
--- a/datasets/com_030d_rw0_fishing_effort_by_zone/fishing-effort_collect-data.py
+++ b/datasets/com_030d_rw0_fishing_effort_by_zone/fishing-effort_collect-data.py
@@ -49,9 +49,9 @@ set_default_credentials(username=CARTO_USER,
                         api_key=CARTO_KEY)
 
 # fixed items defined by gfw
-INITIATE_REPORT_ENDPOINT = 'https://gateway.api.globalfishingwatch.org//v1/reports'
-INQUIRE_STATUS_ENDPOINT = 'https://gateway.api.globalfishingwatch.org//v1/reports/{}'
-RETRIEVE_URL_ENDPOINT = 'https://gateway.api.globalfishingwatch.org//v1/reports/{}/url'
+INITIATE_REPORT_ENDPOINT = 'https://gateway.api.globalfishingwatch.org/v2/reports'
+INQUIRE_STATUS_ENDPOINT = 'https://gateway.api.globalfishingwatch.org/v2/reports/{}'
+RETRIEVE_URL_ENDPOINT = 'https://gateway.api.globalfishingwatch.org/v2/reports/{}/url'
 
 # related objects
 INITIATE_REPORT_HEADERS = {

--- a/datasets/com_030d_rw0_fishing_effort_by_zone/fishing-effort_global-indicator.py
+++ b/datasets/com_030d_rw0_fishing_effort_by_zone/fishing-effort_global-indicator.py
@@ -28,7 +28,7 @@ logger.addHandler(console)
 logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
 # fixed items defined by gfw
-INITIATE_REPORT_ENDPOINT = 'https://gateway.api.globalfishingwatch.org/v1/4wings/report?spatialResolution=low&temporalResolution=yearly&groupBy=flag&datasets[0]=public-global-fishing-effort:latest&date-range={year}-01-01,{year}-12-31&format=json'
+INITIATE_REPORT_ENDPOINT = 'https://gateway.api.globalfishingwatch.org/v2/4wings/report?spatialResolution=low&temporalResolution=yearly&groupBy=flag&datasets[0]=public-global-fishing-effort:latest&date-range={year}-01-01,{year}-12-31&format=json'
 
 # related objects
 INITIATE_REPORT_HEADERS = {

--- a/datasets/com_030d_rw0_fishing_effort_by_zone/fishing-effort_retry-missing.py
+++ b/datasets/com_030d_rw0_fishing_effort_by_zone/fishing-effort_retry-missing.py
@@ -50,9 +50,9 @@ set_default_credentials(username=CARTO_USER,
                         api_key=CARTO_KEY)
 
 # fixed items defined by gfw
-INITIATE_REPORT_ENDPOINT = 'https://gateway.api.globalfishingwatch.org//v1/reports'
-INQUIRE_STATUS_ENDPOINT = 'https://gateway.api.globalfishingwatch.org//v1/reports/{}'
-RETRIEVE_URL_ENDPOINT = 'https://gateway.api.globalfishingwatch.org//v1/reports/{}/url'
+INITIATE_REPORT_ENDPOINT = 'https://gateway.api.globalfishingwatch.org/v2/reports'
+INQUIRE_STATUS_ENDPOINT = 'https://gateway.api.globalfishingwatch.org/v2/reports/{}'
+RETRIEVE_URL_ENDPOINT = 'https://gateway.api.globalfishingwatch.org/v2/reports/{}/url'
 
 # related objects
 INITIATE_REPORT_HEADERS = {

--- a/datasets/com_030d_rw0_fishing_effort_by_zone/fishing-effort_update-data.py
+++ b/datasets/com_030d_rw0_fishing_effort_by_zone/fishing-effort_update-data.py
@@ -39,7 +39,7 @@ set_default_credentials(username=CARTO_USER,
                         api_key=CARTO_KEY)
 
 # fixed items defined by gfw
-INITIATE_REPORT_ENDPOINT = 'https://gateway.api.globalfishingwatch.org/v1/4wings/report?spatialResolution=low&temporalResolution=yearly&groupBy=flag&datasets[0]=public-global-fishing-effort:latest&date-range={year}-01-01,{year}-12-31&format=json'
+INITIATE_REPORT_ENDPOINT = 'https://gateway.api.globalfishingwatch.org/v2/4wings/report?spatialResolution=low&temporalResolution=yearly&groupBy=flag&datasets[0]=public-global-fishing-effort:latest&date-range={year}-01-01,{year}-12-31&format=json'
 
 # related objects
 INITIATE_REPORT_HEADERS = {


### PR DESCRIPTION
Global Fishing Watch (GFW) APIs version 1 was deprecated Oct 31 2022. May 31 2023 it will be deleted. [API v1 deprecation message for WRI.pdf](https://github.com/resource-watch/ocean-watch-data/files/11519956/API.v1.deprecation.message.for.WRI.pdf)

As far as I can tell, these are the only changes need in this repo.